### PR TITLE
mark-devkit: Bump sys-apps/sandbox-2.24-r1

### DIFF
--- a/sys-apps/sandbox/sandbox-2.24-r1.ebuild
+++ b/sys-apps/sandbox/sandbox-2.24-r1.ebuild
@@ -6,7 +6,7 @@ inherit flag-o-matic multilib-minimal multiprocessing
 
 DESCRIPTION="sandbox'd LD_PRELOAD hack"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Sandbox"
-SRC_URI="https://dev.gentoo.org/~slyfox/distfiles/${P}.tar.xz"
+SRC_URI="https://gitweb.gentoo.org/proj/sandbox.git/snapshot/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Automatic bump of package sys-apps/sandbox-2.24-r1 for branch mark-unstable by mark-bot