### PR TITLE
mark-devkit: Bump app-eselect/eselect-cdparanoia-0.1

### DIFF
--- a/app-eselect/eselect-cdparanoia/eselect-cdparanoia-0.1.ebuild
+++ b/app-eselect/eselect-cdparanoia/eselect-cdparanoia-0.1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Manage /usr/bin/cdparanoia symlink"
+HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x86-solaris"
+IUSE=""
+
+RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1
+	!<media-sound/cdparanoia-3.10.2-r5"
+DEPEND=${RDEPEND}
+
+S=${FILESDIR}
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins cdparanoia.eselect-${PV} cdparanoia.eselect
+}

--- a/app-eselect/eselect-cdparanoia/files/cdparanoia.eselect-0.1
+++ b/app-eselect/eselect-cdparanoia/files/cdparanoia.eselect-0.1
@@ -1,0 +1,12 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /usr/bin/cdparanoia implementation"
+MAINTAINER="ssuominen@gentoo.org"
+VERSION="0.1"
+
+SYMLINK_PATH=/usr/bin/cdparanoia
+SYMLINK_TARGETS=( cdparanoia-paranoia libcdio-paranoia )
+SYMLINK_DESCRIPTION='cdparanoia binary'
+
+inherit bin-symlink


### PR DESCRIPTION
Automatic bump of package app-eselect/eselect-cdparanoia-0.1 for branch mark-unstable by mark-bot