### PR TITLE
mark-devkit: Bump app-eselect/eselect-mpg123-0.1

### DIFF
--- a/app-eselect/eselect-mpg123/eselect-mpg123-0.1.ebuild
+++ b/app-eselect/eselect-mpg123/eselect-mpg123-0.1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Manage /usr/bin/mpg123 symlink"
+HOMEPAGE="https://www.gentoo.org/proj/en/eselect/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+IUSE=""
+
+RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1
+	!<media-sound/mpg123-1.14.4-r1"
+DEPEND=${RDEPEND}
+
+S=${FILESDIR}
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins mpg123.eselect-${PV} mpg123.eselect
+}

--- a/app-eselect/eselect-mpg123/files/mpg123.eselect-0.1
+++ b/app-eselect/eselect-mpg123/files/mpg123.eselect-0.1
@@ -1,0 +1,12 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /usr/bin/mpg123 implementation"
+MAINTAINER="ssuominen@gentoo.org"
+VERSION="0.1"
+
+SYMLINK_PATH=/usr/bin/mpg123
+SYMLINK_TARGETS=( mpg123-mpg123 mpg321-mpg123 )
+SYMLINK_DESCRIPTION='mpg123 binary'
+
+inherit bin-symlink


### PR DESCRIPTION
Automatic bump of package app-eselect/eselect-mpg123-0.1 for branch mark-unstable by mark-bot