### PR TITLE
mark-devkit: Bump app-portage/eix-0.36.9-r1

### DIFF
--- a/app-portage/eix/eix-0.36.9-r1.ebuild
+++ b/app-portage/eix/eix-0.36.9-r1.ebuild
@@ -86,6 +86,7 @@ src_install() {
 	default
 	dobashcomp bash/eix
 	dotmpfiles tmpfiles.d/eix.conf
+	echo 'PORTDIR_CACHE_METHOD="parse#metadata-md5#metadata-flat#assign"' >> "${D}"/etc/eixrc/mark.conf
 
 	rm -r "${ED}"/usr/bin/eix-functions.sh || die
 }
@@ -104,3 +105,5 @@ pkg_postrm() {
 		rm -rf "${EROOT}/var/cache/${PN}" || die
 	fi
 }
+
+# vim: syn=ebuild


### PR DESCRIPTION
Automatic bump of package app-portage/eix-0.36.9-r1 for branch mark-unstable by mark-bot