### PR TITLE
Update eix-0.36.9-r2.ebuild: Fix /var/db permissions during post-install

### DIFF
--- a/app-portage/eix/eix-0.36.9-r2.ebuild
+++ b/app-portage/eix/eix-0.36.9-r2.ebuild
@@ -101,6 +101,9 @@ src_install() {
 
 pkg_postinst() {
 	tmpfiles_process eix.conf
+	
+	# Fix /var/db permissions to allow proper metadata access
+	chmod 755 /var/db || die
 
 	local obs=${EROOT}/var/cache/eix.previous
 	if [[ -f ${obs} ]]; then


### PR DESCRIPTION
This change ensures /var/db permissions are corrected during pkg_postinst if they are misconfigured.

Some systems may end up with restrictive permissions on /var/db, which can cause metadata access issues for tools relying on the Portage database. This adjustment safely restores the expected 755 permissions when needed.